### PR TITLE
packaging: Upload attestations to PyPI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,3 +38,5 @@ jobs:
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@v1.10.1
+        with:
+          attestations: true


### PR DESCRIPTION
https://github.com/pypa/gh-action-pypi-publish/tree/v1.10.1/?tab=readme-ov-file#generating-and-uploading-attestations